### PR TITLE
Indicate macOS/Darwin path for gokrazyConfigDir()

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ func userConfigDir() string {
 }
 
 // Typically ~/.config/gokrazy on Linux
+// Typically ~/Library/Application\ Support/gokrazy on macOS/Darwin
 func gokrazyConfigDir() string {
 	return filepath.Join(userConfigDir(), "gokrazy")
 }


### PR DESCRIPTION
The `gokrazyConfigDir()` differs from Linux on macOS/Darwin.
Add a comment for the reader.