### PR TITLE
Use Hostname() for finding cert.pem in httpclient

### DIFF
--- a/httpclient/httpclient.go
+++ b/httpclient/httpclient.go
@@ -39,7 +39,7 @@ func GetTLSHttpClientByTLSFlag(tlsFlag string, tlsInsecure bool, baseUrl *url.UR
 		rootCAs.AppendCertsFromPEM(certBytes)
 	} else {
 		// Try to find a certificate in the local host config
-		hostConfig := config.HostnameSpecific(baseUrl.Host)
+		hostConfig := config.HostnameSpecific(baseUrl.Hostname())
 		certPath := filepath.Join(string(hostConfig), "cert.pem")
 		if _, err := os.Stat(certPath); !os.IsNotExist(err) {
 			foundMatchingCertificate = true


### PR DESCRIPTION
Host might include ports. This is currently probably not an issue, but if other packages (such as `gok`, which I am currently squeezing into shape to allow TLS to work correctly) confront it with URLs with pre-filled ports, it fails to find the certificates.