### PR TITLE
Add minimal xattr support to squashfs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -149,6 +149,8 @@ type PackageConfig struct {
 	// Basename overrides the basename of the package.
 	Basename string `json:",omitempty"`
 
+	Capabilities string `json:",omitempty"`
+
 	// --------------------------------------------------------------------------------
 	// run time package configuration
 	// --------------------------------------------------------------------------------

--- a/squashfs/writer_test.go
+++ b/squashfs/writer_test.go
@@ -43,7 +43,7 @@ func TestUnsquashfs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ff, err := w.Root.File("hellö wörld", time.Now(), 0o444 /* u=r,g=r,o=r */)
+	ff, err := w.Root.File("hellö wörld", time.Now(), 0o444 /* u=r,g=r,o=r */, map[string][]byte{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +54,7 @@ func TestUnsquashfs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ff, err = w.Root.File("leer", time.Now(), 0o444 /* u=r,g=r,o=r */)
+	ff, err = w.Root.File("leer", time.Now(), 0o444 /* u=r,g=r,o=r */, map[string][]byte{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func TestUnsquashfs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ff, err = w.Root.File("second file", time.Now(), 0o555 /* u=rx,g=rx,o=rx */)
+	ff, err = w.Root.File("second file", time.Now(), 0o555 /* u=rx,g=rx,o=rx */, map[string][]byte{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestUnsquashfs(t *testing.T) {
 	subdir := w.Root.Directory("subdir", time.Now())
 
 	subsubdir := subdir.Directory("deep", time.Now())
-	ff, err = subsubdir.File("yo", time.Now(), 0o444 /* u=r,g=r,o=r */)
+	ff, err = subsubdir.File("yo", time.Now(), 0o444 /* u=r,g=r,o=r */, map[string][]byte{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestUnsquashfs(t *testing.T) {
 
 	// TODO: write another file in subdir now, will result in invalid parent inode
 
-	ff, err = subdir.File("third file (in subdir)", time.Now(), 0o444 /* u=r,g=r,o=r */)
+	ff, err = subdir.File("third file (in subdir)", time.Now(), 0o444 /* u=r,g=r,o=r */, map[string][]byte{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func TestUnsquashfs(t *testing.T) {
 	if err := subdir.Flush(); err != nil {
 		t.Fatal(err)
 	}
-	ff, err = w.Root.File("testbin", time.Now(), 0o555 /* u=rx,g=rx,o=rx */)
+	ff, err = w.Root.File("testbin", time.Now(), 0o555 /* u=rx,g=rx,o=rx */, map[string][]byte{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is only implemented to support capabilities on installed go packages.
It should be fairly easy to extend support for xattrs from extra_files if desired
though it would be able to use up this implementations available space quickly.

Note that this does not write multiple metadata blocks to squashfs so ends up
limited on the number and size of xattrs it is capable of writing.
As the purpose was to support 2 executables with a single xattr each the limit of
around 64 unique groups is enough. Xattrs are de-duplicated by group so if any
files share the exact same list of xattrs they will all refer to a single written xattr.